### PR TITLE
Correct checksum

### DIFF
--- a/easylist/ALL/forEblocker.txt
+++ b/easylist/ALL/forEblocker.txt
@@ -1,6 +1,6 @@
 ! Last modified: 14 Jan 2021 11:41 UTC
 ! Expires: 100 days (update frequency)
-! Checksum: 2pumxXXhtG+0kFL5rhkAOA
+! Checksum: c3I7t+Iensty7ynUKwvipg
 011st.com/js/rake/bundle/rake.bundle-0.0.0.js
 1121887754.rsc.cdn77.org/js/shop/emos3.js
 1162911310.rsc.cdn77.org/dist/b/default-9249eebdf6.min.js


### PR DESCRIPTION
I had to fix an [issue in eblocker-lists](https://github.com/eblocker/eblocker-lists/issues/25) due to the cookie list now having a newline character at the end of the file.

The eblocker-lists implementation had the issue that the last character was not included in the checksum if it was a newline character. Now this bug is fixed and it behaves as the [python reference implementation](https://github.com/adblockplus/adblockplus/blob/master/validateChecksum.py).

But now the check fails with `forEblocker.txt` because it was "bug-compatible" with eblocker-lists.
